### PR TITLE
wcnss_lge: include errno.h

### DIFF
--- a/configs/dsi_config.xml
+++ b/configs/dsi_config.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
      DSI Module configuration XML file
      Copyright (c) 2013, 2015 Qualcomm Technologies, Inc.  All Rights Reserved.
      Qualcomm Technologies Proprietary and Confidential.
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <list name="dsi_config">
 
    <!-- Configuration for legacy MSM targets -->

--- a/configs/netmgr_config.xml
+++ b/configs/netmgr_config.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
      Netmgr Module configuration XML file
      Copyright (c) 2013, 2015 Qualcomm Technologies, Inc.  All Rights Reserved.
      Qualcomm Technologies Proprietary and Confidential.
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 
 <!-- QMI configuration -->
 <list name="netmgr_config">

--- a/configs/qmi_config.xml
+++ b/configs/qmi_config.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
      QMI Module configuration XML file
      Copyright (c) 2013-2015 Qualcomm Technologies, Inc.  All Rights Reserved.
      Qualcomm Technologies Proprietary and Confidential.
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 
 <!-- QMI configuration -->
 <list name="qmi_config">

--- a/msm8916.mk
+++ b/msm8916.mk
@@ -50,7 +50,6 @@ PRODUCT_PACKAGES += \
     audio.primary.msm8916 \
     audio.r_submix.default \
     audio.usb.default \
-    libqcompostprocbundle \
     libqcomvisualizer \
     libqcomvoiceprocessing
 

--- a/wcnss_lge/wcnss_lge_client.c
+++ b/wcnss_lge/wcnss_lge_client.c
@@ -24,6 +24,7 @@
 #define CALIBRATION_PATH "/dev/block/bootdevice/by-name/misc"
 
 #include <cutils/log.h>
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdio.h>


### PR DESCRIPTION
Change-Id: Id9b6085fcabd1e3eb01fdabbca060a858064e2e9

This is to fix a build error in CM 13.
